### PR TITLE
Downgrade Slick.js and removes invalid self-closing tags

### DIFF
--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1861,7 +1861,7 @@
         var _ = this, breakpoint, currentBreakpoint, l,
             responsiveSettings = _.options.responsive || null;
 
-        if ( $.type(responsiveSettings) === 'array' && responsiveSettings.length ) {
+        if ( typeof responsiveSettings === 'array' && responsiveSettings.length ) {
 
             _.respondTo = _.options.respondTo || 'window';
 
@@ -2125,19 +2125,19 @@
 
         var _ = this, l, item, option, value, refresh = false, type;
 
-        if( $.type( arguments[0] ) === 'object' ) {
+        if( typeof arguments[0] === 'object' ) {
 
             option =  arguments[0];
             refresh = arguments[1];
             type = 'multiple';
 
-        } else if ( $.type( arguments[0] ) === 'string' ) {
+        } else if ( typeof arguments[0] === 'string' ) {
 
             option =  arguments[0];
             value = arguments[1];
             refresh = arguments[2];
 
-            if ( arguments[0] === 'responsive' && $.type( arguments[1] ) === 'array' ) {
+            if ( arguments[0] === 'responsive' && typeof arguments[1] === 'array' ) {
 
                 type = 'responsive';
 
@@ -2167,7 +2167,7 @@
 
             for ( item in value ) {
 
-                if( $.type( _.options.responsive ) !== 'array' ) {
+                if( typeof _.options.responsive !== 'array' ) {
 
                     _.options.responsive = [ value[item] ];
 

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -6,7 +6,7 @@
 |___/_|_|\___|_|\_(_)/ |___/
                    |__/
 
- Version: 1.8.1
+ Version: 1.8.0 (modified)
   Author: Ken Wheeler
  Website: http://kenwheeler.github.io
     Docs: http://kenwheeler.github.io/slick
@@ -52,7 +52,7 @@
                 centerPadding: '50px',
                 cssEase: 'ease',
                 customPaging: function(slider, i) {
-                    return $('<button type="button" />').text(i + 1);
+                    return $( '<button type="button"></button>' ).text(i + 1);
                 },
                 dots: false,
                 dotsClass: 'slick-dots',
@@ -488,10 +488,10 @@
 
             _.$slider.addClass('slick-dotted');
 
-            dot = $('<ul />').addClass(_.options.dotsClass);
+            dot = $( '<ul></ul>' ).addClass( _.options.dotsClass );
 
             for (i = 0; i <= _.getDotCount(); i += 1) {
-                dot.append($('<li />').append(_.options.customPaging.call(this, _, i)));
+                dot.append( $( '<li></li>' ).append( _.options.customPaging.call( this, _, i ) ) );
             }
 
             _.$dots = dot.appendTo(_.options.appendDots);
@@ -522,11 +522,11 @@
         _.$slider.addClass('slick-slider');
 
         _.$slideTrack = (_.slideCount === 0) ?
-            $('<div class="slick-track"/>').appendTo(_.$slider) :
-            _.$slides.wrapAll('<div class="slick-track"/>').parent();
+            $( '<div class="slick-track"></div>' ).appendTo( _.$slider ) :
+            _.$slides.wrapAll( '<div class="slick-track"></div>' ).parent();
 
         _.$list = _.$slideTrack.wrap(
-            '<div class="slick-list"/>').parent();
+            '<div class="slick-list"></div>' ).parent();
         _.$slideTrack.css('opacity', 0);
 
         if (_.options.centerMode === true || _.options.swipeToSlide === true) {
@@ -1014,37 +1014,23 @@
 
         var _ = this;
 
-        // If any child element receives focus within the slider we need to pause the autoplay
         _.$slider
             .off('focus.slick blur.slick')
-            .on(
-                'focus.slick',
-                '*', 
-                function(event) {
-                    var $sf = $(this);
+            .on('focus.slick blur.slick', '*', function(event) {
 
-                    setTimeout(function() {
-                        if( _.options.pauseOnFocus ) {
-                            if ($sf.is(':focus')) {
-                                _.focussed = true;
-                                _.autoPlay();
-                            }
-                        }
-                    }, 0);
-                }
-            ).on(
-                'blur.slick',
-                '*', 
-                function(event) {
-                    var $sf = $(this);
+            event.stopImmediatePropagation();
+            var $sf = $(this);
 
-                    // When a blur occurs on any elements within the slider we become unfocused
-                    if( _.options.pauseOnFocus ) {
-                        _.focussed = false;
-                        _.autoPlay();
-                    }
+            setTimeout(function() {
+
+                if( _.options.pauseOnFocus ) {
+                    _.focussed = $sf.is(':focus');
+                    _.autoPlay();
                 }
-            );
+
+            }, 0);
+
+        });
     };
 
     Slick.prototype.getCurrent = Slick.prototype.slickCurrentSlide = function() {
@@ -1238,25 +1224,13 @@
     Slick.prototype.getSlideCount = function() {
 
         var _ = this,
-            slidesTraversed, swipedSlide, swipeTarget, centerOffset;
+            slidesTraversed, swipedSlide, centerOffset;
 
-        centerOffset = _.options.centerMode === true ? Math.floor(_.$list.width() / 2) : 0;
-        swipeTarget = (_.swipeLeft * -1) + centerOffset;
+        centerOffset = _.options.centerMode === true ? _.slideWidth * Math.floor(_.options.slidesToShow / 2) : 0;
 
         if (_.options.swipeToSlide === true) {
-
             _.$slideTrack.find('.slick-slide').each(function(index, slide) {
-
-                var slideOuterWidth, slideOffset, slideRightBoundary;
-                slideOuterWidth = $(slide).outerWidth();
-                slideOffset = slide.offsetLeft;
-                if (_.options.centerMode !== true) {
-                    slideOffset += (slideOuterWidth / 2);
-                }
-
-                slideRightBoundary = slideOffset + (slideOuterWidth);
-
-                if (swipeTarget < slideRightBoundary) {
+                if (slide.offsetLeft - centerOffset + ($(slide).outerWidth() / 2) > (_.swipeLeft * -1)) {
                     swipedSlide = slide;
                     return false;
                 }
@@ -2354,7 +2328,7 @@
                 if (index === 0) {
 
                     allSlides
-                        .eq( _.options.slidesToShow + _.slideCount + 1 )
+                        .eq(allSlides.length - 1 - _.options.slidesToShow)
                         .addClass('slick-center');
 
                 } else if (index === _.slideCount - 1) {

--- a/slick/slick.js
+++ b/slick/slick.js
@@ -1861,7 +1861,7 @@
         var _ = this, breakpoint, currentBreakpoint, l,
             responsiveSettings = _.options.responsive || null;
 
-        if ( typeof responsiveSettings === 'array' && responsiveSettings.length ) {
+        if ( responsiveSettings.length ) {
 
             _.respondTo = _.options.respondTo || 'window';
 


### PR DESCRIPTION
This commit reverts slick back to 1.8.0 (the last release build) and removes invalid self-closing tags.
The version was reverted because we have already implemented a method of dealing with this. If further changes are made and a proper release is done we'll look at supporting that version.